### PR TITLE
chore: add missing machine readable license information

### DIFF
--- a/packages/admin-stylelint-rules/package.json
+++ b/packages/admin-stylelint-rules/package.json
@@ -2,7 +2,7 @@
 	"name": "@shopware-ag/admin-stylelint-rules",
 	"version": "1.0.1",
 	"license": "MIT",
-	"author": "Shopware AG",
+	"author": "shopware AG",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/shopwareLabs/shopware-javascript-code-quality.git",

--- a/packages/admin-stylelint-rules/package.json
+++ b/packages/admin-stylelint-rules/package.json
@@ -1,6 +1,8 @@
 {
 	"name": "@shopware-ag/admin-stylelint-rules",
 	"version": "1.0.1",
+	"license": "MIT",
+	"author": "Shopware AG",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/shopwareLabs/shopware-javascript-code-quality.git",

--- a/packages/storefront-eslint-rules/package.json
+++ b/packages/storefront-eslint-rules/package.json
@@ -2,6 +2,8 @@
 	"name": "@shopware-ag/storefront-eslint-rules",
 	"version": "1.0.0",
 	"description": "Shopware Storefront ESLint rules",
+	"license": "MIT",
+	"author": "Shopware AG",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/shopwareLabs/shopware-javascript-code-quality.git",

--- a/packages/storefront-eslint-rules/package.json
+++ b/packages/storefront-eslint-rules/package.json
@@ -3,7 +3,7 @@
 	"version": "1.0.0",
 	"description": "Shopware Storefront ESLint rules",
 	"license": "MIT",
-	"author": "Shopware AG",
+	"author": "shopware AG",
 	"repository": {
 		"type": "git",
 		"url": "https://github.com/shopwareLabs/shopware-javascript-code-quality.git",


### PR DESCRIPTION
Ive noticed the LICENSE file in the repo, 
but that only 1 of the 3 packages had the license set in the machine readable field.