### PR TITLE
Add License Meta Data in Package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,5 +9,6 @@
 		"oxfmt": "^0.33.0",
 		"oxlint": "^1.48.0"
 	},
-	"packageManager": "pnpm@10.28.1"
+	"packageManager": "pnpm@10.28.1",
+	"license": "MIT"
 }


### PR DESCRIPTION
According to <https://www.npmjs.com/package/@shopware-ag/storefront-eslint-rules> This project has no license.

This adds in the license Identifier matching the LICENSE into the package.json